### PR TITLE
Set directory picker to readwrite mode for UF2 copying

### DIFF
--- a/src/lib/DeviceContext.js
+++ b/src/lib/DeviceContext.js
@@ -330,7 +330,7 @@ export function DeviceProvider({ children }) {
   }, [sendRaw])
 
   const copyUF2 = useCallback(async file => {
-    const dir = await window.showDirectoryPicker()
+    const dir = await window.showDirectoryPicker({ mode: 'readwrite' })
     const handle = await dir.getFileHandle(file.name, { create: true })
     const writable = await handle.createWritable()
     await writable.write(await file.arrayBuffer())


### PR DESCRIPTION
## Summary
- ensure the UF2 copy flow requests a read/write directory handle so files can be created on the target drive

## Testing
- npm run lint
- manually verified UF2 copy succeeds via browser automation

------
https://chatgpt.com/codex/tasks/task_e_68d1a8b36b2c83279b296a5d76b6792d